### PR TITLE
Add blog post on LLM routing and migration to agentgateway

### DIFF
--- a/content/posts/07-intel-homelab-5.md
+++ b/content/posts/07-intel-homelab-5.md
@@ -1,7 +1,7 @@
 +++
 authors = ["Kalin Daskalov"]
 title = "Lab Notes: Why llm-d pushed me out of Ingress (and into agentgateway)"
-date = "2026-04-08"
+date = "2026-04-14"
 description = "When LLM routing became a scheduling problem, ingress stopped being enough."
 categories = ["lab notes"]
 tags = ["k8s", "mlops", "intel", "homelab", "devops", "kubernetes", "k3s", "llm-d", "gateway-api", "agentgateway", "fluxcd", "openwebui", "vllm"]
@@ -17,7 +17,7 @@ tags = ["k8s", "mlops", "intel", "homelab", "devops", "kubernetes", "k3s", "llm-
 - [Table of Contents](#table-of-contents)
 - [00 This started as "just expose one more endpoint"](#00-this-started-as-just-expose-one-more-endpoint)
 - [01 Why Ingress was no longer enough](#01-why-ingress-was-no-longer-enough)
-- [02 The second migration I did not plan](#02-the-second-migration-i-did-not-plan)
+- [02 The second migration](#02-the-second-migration)
 - [03 Timeouts became part of architecture](#03-timeouts-became-part-of-architecture)
 - [04 Where the stack landed](#04-where-the-stack-landed)
 - [05 Closing notes](#05-closing-notes)
@@ -26,27 +26,38 @@ tags = ["k8s", "mlops", "intel", "homelab", "devops", "kubernetes", "k3s", "llm-
 
 ## 00 This started as "just expose one more endpoint"
 
-I thought this would be a small networking change.
+In Part 4, I introduced `llm-d`. It was a solution after my original thought that inference on Kubernetes can follow a "standard" path of:
 
-At first, my mental model was simple: I already had UI traffic working, so I just needed one more route for inference and we were done.
+1. Get a model running locally
+2. Run it in a container
+3. Run it in Kubernetes
+4. Expose it with Ingress
 
-That model was wrong.
+Step 4 was the original plan. I had Ingress in place for all my other apps, so it felt natural to just add another route.
 
-Once `llm-d` became the center of inference, routing stopped being "send traffic to a Service" and became "send traffic to a scheduler that understands LLM backends." That subtle shift is where Ingress stopped fitting naturally.
+With one model pod, Ingress looks fine. With two replicas serving the same model, the question changes from "which Service" to "which replica should take this request right now." Ingress only sees HTTP endpoints. It does not know anything about decode pods, cache locality, or inference-specific backends, while llm-d's scheduler does.
 
-At the same time, the gateway implementation itself changed under me: while I was moving away from Ingress, `kgateway` was being deprecated and I had to migrate to `agentgateway` too.
+Once `llm-d` became the center of inference is where Ingress stopped fitting naturally.
 
-So this post is the bigger picture behind that migration path:
+The routing question was no longer "which Service" but "which inference pool backend." Inference pools are a new kind of backend that encode model-serving semantics, and they are only supported in Gateway API with the Inference Extension.
+
+Kubernetes docs now [explicitly recommend Gateway API over Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/#what-is-ingress), and the Ingress API is marked as frozen (stable, but no new feature development). Around the same time, `ingress-nginx` retirement was [announced on November 11, 2025](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/), with best-effort maintenance through March 2026.
+
+So the path became clear: keep existing Ingress where needed, but invest new routing work in Gateway API.
+
+One dependency bump later, I learned this was not one migration but two:
 
 1. Ingress -> Gateway API because of `llm-d`
-2. `kgateway` -> `agentgateway` because the provider changed
-3. Timeout and connection handling changes because LLM traffic is long lived by default
+2. `kgateway` -> `agentgateway` because the provider path changed
+3. Timeout/connection policy changes because LLM traffic is long-lived by default
+
+I originally chose `kgateway` for its early Gateway API support, but the provider ecosystem is still evolving. When `agentgateway` emerged with a more focused vision on AI workloads, it made sense to follow that path.
 
 ---
 
 ## 01 Why Ingress was no longer enough
 
-`llm-d` depends on Gateway API Inference Extension CRDs, so Gateway API became a hard dependency, not a preference.
+`llm-d` depends on Gateway API Inference Extension CRDs, so Gateway API became a hard dependency in this repo.
 
 ```yaml
 # infrastructure/gateway-api/gateway-api-inference-extension.yaml
@@ -83,7 +94,7 @@ rules:
         port: 8200
 ```
 
-And the pool defines the model backend semantics (`v1` API, decode label matching, target port):
+And the pool encodes model-backend semantics (`v1` API, decode label selection, target port):
 
 ```yaml
 # deployments/llm-d/inference-scheduling/inferencepool/inferencepool-values.yaml
@@ -96,15 +107,27 @@ inferencePool:
       llm-d.ai/role: "decode"
 ```
 
-So this was the key realization for me: Ingress was still useful for web apps, but my inference path was no longer just web routing.
+At that point, I could have kept a mixed world: Ingress for apps, Gateway API for inference. I decided not to. Running two routing models in parallel was extra cognitive overhead for policy, debugging, and observability. Since `llm-d` already forced me to learn Gateway API, consolidating routes made more sense.
+
+The unplanned part came next.
 
 ---
 
-## 02 The second migration I did not plan
+## 02 The second migration
 
-I started the first migration with `kgateway` and in the middle of that work, the direction shifted to `agentgateway`.
+A concrete timeline from my infra repo:
 
-The base swap looked small:
+1. `f01d2cf` (2026-02-07): migrate app ingress routes to Gateway API
+2. `0a1415d` (2026-02-07): migrate infra ingress routes (`Flux`, `MinIO`, `Grafana`, `Prometheus`, `VictoriaLogs`)
+3. `829d7a4` (2026-02-13): split `OpenWebUI` route behavior and add long-stream policy
+4. `7b9a137` -> `4fde0b6` (2026-04-07): Gateway API dependency bump to `v1.5.1`, then revert to `v1.4.1`
+5. `1904628` + `8397a51` (2026-04-07): `kgateway` -> `agentgateway` refactor plus listener/route cleanup
+
+The revert on step 4 was where I learned about the provider migration. I had been following `kgateway` releases, but I missed the deprecation notice for AI Gateway support. When I bumped to `v1.5.1`, all my inference routes stopped working and I had to dig into release notes and code to understand why.
+
+The key nuance: `kgateway` was not dead. The AI/inference path moved. In `kgateway` 2.1 release notes, AI Gateway and Gateway API Inference Extension support on Envoy-based proxies was marked deprecated in favor of `agentgateway` proxy support, with removal planned in 2.2. Then 2.2 introduced dedicated `agentgateway.dev` APIs and a separate chart/controller split ([release notes](https://kgateway.dev/docs/envoy/latest/reference/release-notes/), [2.2 breaking changes](https://kgateway.dev/docs/2.2.x/release-notes/breaking-changes/)).
+
+The obvious diff looked small:
 
 ```diff
 # commit 1904628 (llm-d infra values)
@@ -115,10 +138,16 @@ The base swap looked small:
 + gatewayClassName: agentgateway
 ```
 
-But it was not just two lines. Listener names, route section references, and route shape had to move together.
+But there was more surface area:
 
 ```diff
-# commit 8397a51 (gateway/listener + route cleanup)
+# commit 1904628 (route parent refs)
+- namespace: kgateway-system
++ namespace: agentgateway-system
+```
+
+```diff
+# commit 8397a51 (listener + route cleanup)
 - - name: infer-https
 + - name: inference-gateway-https
 
@@ -129,13 +158,13 @@ But it was not just two lines. Listener names, route section references, and rou
 + # removed and consolidated around HTTPS listeners
 ```
 
-The lesson for me was practical: in Gateway API setups, `sectionName` is a real contract. Renaming listeners is easy. Renaming listeners without breaking every dependent `HTTPRoute` is the real work.
+After I stabilized these bindings, the next bottleneck was connection behavior.
 
 ---
 
 ## 03 Timeouts became part of architecture
 
-The long-connection behavior of LLM inference and UI sessions forced me to treat timeout config as core architecture, not optional tuning.
+The long-connection behavior of LLM inference and UI sessions forced me to treat timeout config as architecture, not optional tuning.
 
 For external inference traffic:
 
@@ -165,7 +194,7 @@ rules:
       request: "0s"
 ```
 
-If you are serving short APIs, default timeouts can be perfectly fine. If you are serving long streams and slower model turns, default assumptions can quietly wreck UX and make failures look random.
+If you serve short request/response APIs, defaults are often fine. If you serve token streams and slower model turns, default timeout assumptions can quietly wreck UX. I started receiving strange "connection reset" errors in OpenWebUI and llm-d, and it took a while to connect the dots that these were not random network issues but timeout policies kicking in.
 
 ---
 
@@ -197,8 +226,8 @@ This ended up cleaner than what I had before:
 
 1. Gateway API is now a stable dependency of the inference stack
 2. `llm-d` routing semantics are explicit in manifests
-3. The provider migration is complete and aligned with the current gateway control plane
-4. Long-lived connection behavior is handled where it should be: in route policy
+3. The provider migration is complete and aligned with the current control plane
+4. Long-lived connection behavior is handled in route policy, not left to defaults
 
 ---
 
@@ -206,10 +235,6 @@ This ended up cleaner than what I had before:
 
 What I expected to be one migration taught me three separate lessons:
 
-1. Inference routing is not generic web routing
-2. Gateway provider lifecycle matters as much as application lifecycle
-3. Timeout policy is part of product behavior when LLMs are in the loop
-
-I still think of this as MVP territory, but it is a more honest MVP now. The manifests encode the real behavior instead of relying on defaults and luck.
-
-In the next notes, I want to go deeper on request-level behavior through the pool itself: what gets routed where, and why.
+1. Inference routing is not generic web routing, I think I'm spending the bulk of my time on these issues because of the unique semantics of LLM workloads, not just because of the newness of Gateway API.
+2. Gateway provider lifecycle matters as much as application lifecycle, especially in a fast-evolving space like AI inference. I had to follow the provider ecosystem and be ready to adapt when the path changed. Things really are moving too fast. I go on a vacation and miss a release, and suddenly my whole routing layer breaks because of a provider migration I didn't know was coming.
+3. Timeout policy is part of product behavior when LLMs are in the loop, connection is more akin to a session than a request, and the "request" can be arbitrarily long.

--- a/content/posts/07-intel-homelab-5.md
+++ b/content/posts/07-intel-homelab-5.md
@@ -1,0 +1,215 @@
++++
+authors = ["Kalin Daskalov"]
+title = "Lab Notes: Why llm-d pushed me out of Ingress (and into agentgateway)"
+date = "2026-04-08"
+description = "When LLM routing became a scheduling problem, ingress stopped being enough."
+categories = ["lab notes"]
+tags = ["k8s", "mlops", "intel", "homelab", "devops", "kubernetes", "k3s", "llm-d", "gateway-api", "agentgateway", "fluxcd", "openwebui", "vllm"]
++++
+
+> Link to Part 4: [Intel AI Inference Platform MVP 2 with llm-d](https://blog.sonda.red/posts/06-intel-homelab-4/)
+
+> Disclaimer: This is not production guidance and it is not sponsored. It documents what actually ran in my homelab. Please double-check before you roll it into your own setup.
+
+---
+
+## Table of Contents
+- [Table of Contents](#table-of-contents)
+- [00 This started as "just expose one more endpoint"](#00-this-started-as-just-expose-one-more-endpoint)
+- [01 Why Ingress was no longer enough](#01-why-ingress-was-no-longer-enough)
+- [02 The second migration I did not plan](#02-the-second-migration-i-did-not-plan)
+- [03 Timeouts became part of architecture](#03-timeouts-became-part-of-architecture)
+- [04 Where the stack landed](#04-where-the-stack-landed)
+- [05 Closing notes](#05-closing-notes)
+
+---
+
+## 00 This started as "just expose one more endpoint"
+
+I thought this would be a small networking change.
+
+At first, my mental model was simple: I already had UI traffic working, so I just needed one more route for inference and we were done.
+
+That model was wrong.
+
+Once `llm-d` became the center of inference, routing stopped being "send traffic to a Service" and became "send traffic to a scheduler that understands LLM backends." That subtle shift is where Ingress stopped fitting naturally.
+
+At the same time, the gateway implementation itself changed under me: while I was moving away from Ingress, `kgateway` was being deprecated and I had to migrate to `agentgateway` too.
+
+So this post is the bigger picture behind that migration path:
+
+1. Ingress -> Gateway API because of `llm-d`
+2. `kgateway` -> `agentgateway` because the provider changed
+3. Timeout and connection handling changes because LLM traffic is long lived by default
+
+---
+
+## 01 Why Ingress was no longer enough
+
+`llm-d` depends on Gateway API Inference Extension CRDs, so Gateway API became a hard dependency, not a preference.
+
+```yaml
+# infrastructure/gateway-api/gateway-api-inference-extension.yaml
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: gateway-api-inference-extension
+  namespace: gateway-system
+spec:
+  url: https://github.com/kubernetes-sigs/gateway-api-inference-extension
+  ref:
+    tag: v1.4.0
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: gateway-api-inference-extension
+  namespace: gateway-system
+spec:
+  path: ./config/crd
+  dependsOn:
+    - name: gateway-api
+```
+
+Then the route itself stopped targeting a plain Service and started targeting an `InferencePool`.
+
+```yaml
+# deployments/llm-d/inference-scheduling/httproute.yaml
+rules:
+  - backendRefs:
+      - name: llm-d-inferencepool
+        kind: InferencePool
+        group: inference.networking.k8s.io
+        port: 8200
+```
+
+And the pool defines the model backend semantics (`v1` API, decode label matching, target port):
+
+```yaml
+# deployments/llm-d/inference-scheduling/inferencepool/inferencepool-values.yaml
+inferencePool:
+  apiVersion: inference.networking.k8s.io/v1
+  targetPortNumber: 8200
+  modelServerType: vllm
+  modelServers:
+    matchLabels:
+      llm-d.ai/role: "decode"
+```
+
+So this was the key realization for me: Ingress was still useful for web apps, but my inference path was no longer just web routing.
+
+---
+
+## 02 The second migration I did not plan
+
+I started the first migration with `kgateway` and in the middle of that work, the direction shifted to `agentgateway`.
+
+The base swap looked small:
+
+```diff
+# commit 1904628 (llm-d infra values)
+- provider: kgateway
++ provider: agentgateway
+
+- gatewayClassName: kgateway
++ gatewayClassName: agentgateway
+```
+
+But it was not just two lines. Listener names, route section references, and route shape had to move together.
+
+```diff
+# commit 8397a51 (gateway/listener + route cleanup)
+- - name: infer-https
++ - name: inference-gateway-https
+
+- - name: agtw-https
++ - name: agentgateway-admin-ui-https
+
+- # HTTP to HTTPS redirect routes
++ # removed and consolidated around HTTPS listeners
+```
+
+The lesson for me was practical: in Gateway API setups, `sectionName` is a real contract. Renaming listeners is easy. Renaming listeners without breaking every dependent `HTTPRoute` is the real work.
+
+---
+
+## 03 Timeouts became part of architecture
+
+The long-connection behavior of LLM inference and UI sessions forced me to treat timeout config as core architecture, not optional tuning.
+
+For external inference traffic:
+
+```yaml
+# deployments/llm-d/inference-scheduling/httproute-external.yaml
+rules:
+  - matches:
+      - path:
+          type: PathPrefix
+          value: /
+    timeouts:
+      backendRequest: "3600s"
+      request: "0s"
+```
+
+For OpenWebUI:
+
+```yaml
+# deployments/openwebui/httproute.yaml
+rules:
+  - matches:
+      - path:
+          type: PathPrefix
+          value: /
+    timeouts:
+      backendRequest: "3600s"
+      request: "0s"
+```
+
+If you are serving short APIs, default timeouts can be perfectly fine. If you are serving long streams and slower model turns, default assumptions can quietly wreck UX and make failures look random.
+
+---
+
+## 04 Where the stack landed
+
+The current gateway shape is one shared `main-gateway` in `agentgateway-system`, with explicit HTTPS listeners per hostname.
+
+```yaml
+# infrastructure/agentgateway/gateway.yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: main-gateway
+  namespace: agentgateway-system
+spec:
+  gatewayClassName: agentgateway
+  listeners:
+    - name: openwebui-https
+      hostname: chat.sonda.red.intra
+      port: 443
+      protocol: HTTPS
+    - name: inference-gateway-https
+      hostname: infer.sonda.red.intra
+      port: 443
+      protocol: HTTPS
+```
+
+This ended up cleaner than what I had before:
+
+1. Gateway API is now a stable dependency of the inference stack
+2. `llm-d` routing semantics are explicit in manifests
+3. The provider migration is complete and aligned with the current gateway control plane
+4. Long-lived connection behavior is handled where it should be: in route policy
+
+---
+
+## 05 Closing notes
+
+What I expected to be one migration taught me three separate lessons:
+
+1. Inference routing is not generic web routing
+2. Gateway provider lifecycle matters as much as application lifecycle
+3. Timeout policy is part of product behavior when LLMs are in the loop
+
+I still think of this as MVP territory, but it is a more honest MVP now. The manifests encode the real behavior instead of relying on defaults and luck.
+
+In the next notes, I want to go deeper on request-level behavior through the pool itself: what gets routed where, and why.

--- a/content/posts/07-intel-homelab-5.md
+++ b/content/posts/07-intel-homelab-5.md
@@ -15,17 +15,21 @@ tags = ["k8s", "mlops", "intel", "homelab", "devops", "kubernetes", "k3s", "llm-
 
 ## Table of Contents
 - [Table of Contents](#table-of-contents)
-- [00 This started as "just expose one more endpoint"](#00-this-started-as-just-expose-one-more-endpoint)
-- [01 Why Ingress was no longer enough](#01-why-ingress-was-no-longer-enough)
-- [02 The second migration](#02-the-second-migration)
-- [03 Timeouts became part of architecture](#03-timeouts-became-part-of-architecture)
+- [00 I came back from vacation to a broken routing layer](#00-i-came-back-from-vacation-to-a-broken-routing-layer)
+- [01 Why Ingress couldn't follow](#01-why-ingress-couldnt-follow)
+- [02 The migration I didn't plan for](#02-the-migration-i-didnt-plan-for)
+- [03 When timeouts become product behavior](#03-when-timeouts-become-product-behavior)
 - [04 Where the stack landed](#04-where-the-stack-landed)
-- [05 Closing notes](#05-closing-notes)
+- [05 Three lessons from three migrations](#05-three-lessons-from-three-migrations)
 - [References](#references)
 
 ---
 
-## 00 This started as "just expose one more endpoint"
+## 00 I came back from vacation to a broken routing layer
+
+So I went on vacation for a week. Before I left I had queued a minor version bump on the gateway provider. Came back, checked Flux, and nothing was routing. All inference traffic was dead. Turns out the provider had deprecated the AI Gateway path I was using and I just hadn't noticed the release notes.
+
+That was fun to debug on a Monday morning. But it also made me realize this whole thing was not one migration but three, and I should probably write down how I got here.
 
 In Part 4, I introduced `llm-d`. It was a solution after my original thought that inference on Kubernetes can follow a "standard" path of:
 
@@ -56,7 +60,7 @@ I originally chose `kgateway` for its early Gateway API support, but the provide
 
 ---
 
-## 01 Why Ingress was no longer enough
+## 01 Why Ingress couldn't follow
 
 `llm-d` depends on Gateway API Inference Extension CRDs, so Gateway API became a hard dependency in this repo.
 
@@ -108,13 +112,13 @@ inferencePool:
       llm-d.ai/role: "decode"
 ```
 
-At that point, I could have kept a mixed world: Ingress for apps, Gateway API for inference. I decided not to. Running two routing models in parallel was extra cognitive overhead for policy, debugging, and observability. Since `llm-d` already forced me to learn Gateway API, consolidating routes made more sense.
+At that point I could have just left Ingress in place for the non-inference apps and only used Gateway API for `llm-d`. I thought about it for maybe a day. Running two routing stacks in parallel sounded like the kind of decision I'd regret every time something broke and I had to check both. Since I already had to learn Gateway API anyway, I just moved everything over.
 
-The unplanned part came next.
+The part I didn't plan for came next.
 
 ---
 
-## 02 The second migration
+## 02 The migration I didn't plan for
 
 A concrete timeline from my infra repo:
 
@@ -163,7 +167,7 @@ After I stabilized these bindings, the next bottleneck was connection behavior.
 
 ---
 
-## 03 Timeouts became part of architecture
+## 03 When timeouts become product behavior
 
 The long-connection behavior of LLM inference and UI sessions forced me to treat timeout config as architecture, not optional tuning.
 
@@ -232,12 +236,12 @@ This ended up cleaner than what I had before:
 
 ---
 
-## 05 Closing notes
+## 05 Three lessons from three migrations
 
 What I expected to be one migration taught me three separate lessons:
 
 1. Inference routing is not generic web routing. I think I'm spending the bulk of my time on these issues because of the unique semantics of LLM workloads, not just because of the newness of Gateway API.
-2. Gateway provider lifecycle matters as much as application lifecycle, especially in a fast-evolving space like AI inference. I had to follow the provider ecosystem and be ready to adapt when the path changed. Things really are moving too fast. I go on a vacation and miss a release, and suddenly my whole routing layer breaks because of a provider migration I didn't know was coming.
+2. Gateway provider lifecycle matters as much as application lifecycle. I missed one release, went on vacation, came back to a dead routing layer. Things are moving fast in this space and nobody is going to wait for you to catch up.
 3. Timeout policy is part of product behavior when LLMs are in the loop. A connection is more akin to a session than a request, and the "request" can be arbitrarily long.
 
 ---

--- a/content/posts/07-intel-homelab-5.md
+++ b/content/posts/07-intel-homelab-5.md
@@ -21,6 +21,7 @@ tags = ["k8s", "mlops", "intel", "homelab", "devops", "kubernetes", "k3s", "llm-
 - [03 Timeouts became part of architecture](#03-timeouts-became-part-of-architecture)
 - [04 Where the stack landed](#04-where-the-stack-landed)
 - [05 Closing notes](#05-closing-notes)
+- [References](#references)
 
 ---
 

--- a/content/posts/07-intel-homelab-5.md
+++ b/content/posts/07-intel-homelab-5.md
@@ -37,7 +37,7 @@ Step 4 was the original plan. I had Ingress in place for all my other apps, so i
 
 With one model pod, Ingress looks fine. With two replicas serving the same model, the question changes from "which Service" to "which replica should take this request right now." Ingress only sees HTTP endpoints. It does not know anything about decode pods, cache locality, or inference-specific backends, while llm-d's scheduler does.
 
-Once `llm-d` became the center of inference is where Ingress stopped fitting naturally.
+Once `llm-d` became the center of inference, Ingress stopped fitting naturally.
 
 The routing question was no longer "which Service" but "which inference pool backend." Inference pools are a new kind of backend that encode model-serving semantics, and they are only supported in Gateway API with the Inference Extension.
 
@@ -45,11 +45,11 @@ Kubernetes docs now [explicitly recommend Gateway API over Ingress](https://kube
 
 So the path became clear: keep existing Ingress where needed, but invest new routing work in Gateway API.
 
-One dependency bump later, I learned this was not one migration but two:
+One dependency bump later, I learned this was not one migration but three:
 
 1. Ingress -> Gateway API because of `llm-d`
 2. `kgateway` -> `agentgateway` because the provider path changed
-3. Timeout/connection policy changes because LLM traffic is long-lived by default
+3. Default timeouts -> explicit timeout policies because LLM traffic is long-lived
 
 I originally chose `kgateway` for its early Gateway API support, but the provider ecosystem is still evolving. When `agentgateway` emerged with a more focused vision on AI workloads, it made sense to follow that path.
 
@@ -123,7 +123,7 @@ A concrete timeline from my infra repo:
 4. `7b9a137` -> `4fde0b6` (2026-04-07): Gateway API dependency bump to `v1.5.1`, then revert to `v1.4.1`
 5. `1904628` + `8397a51` (2026-04-07): `kgateway` -> `agentgateway` refactor plus listener/route cleanup
 
-The revert on step 4 was where I learned about the provider migration. I had been following `kgateway` releases, but I missed the deprecation notice for AI Gateway support. When I bumped to `v1.5.1`, all my inference routes stopped working and I had to dig into release notes and code to understand why.
+The revert in step 4 was where I learned about the provider migration. I had been following `kgateway` releases, but I missed the deprecation notice for AI Gateway support. When I bumped to `v1.5.1`, all my inference routes stopped working and I had to dig into release notes and code to understand why.
 
 The key nuance: `kgateway` was not dead. The AI/inference path moved. In `kgateway` 2.1 release notes, AI Gateway and Gateway API Inference Extension support on Envoy-based proxies was marked deprecated in favor of `agentgateway` proxy support, with removal planned in 2.2. Then 2.2 introduced dedicated `agentgateway.dev` APIs and a separate chart/controller split ([release notes](https://kgateway.dev/docs/envoy/latest/reference/release-notes/), [2.2 breaking changes](https://kgateway.dev/docs/2.2.x/release-notes/breaking-changes/)).
 
@@ -235,6 +235,20 @@ This ended up cleaner than what I had before:
 
 What I expected to be one migration taught me three separate lessons:
 
-1. Inference routing is not generic web routing, I think I'm spending the bulk of my time on these issues because of the unique semantics of LLM workloads, not just because of the newness of Gateway API.
+1. Inference routing is not generic web routing. I think I'm spending the bulk of my time on these issues because of the unique semantics of LLM workloads, not just because of the newness of Gateway API.
 2. Gateway provider lifecycle matters as much as application lifecycle, especially in a fast-evolving space like AI inference. I had to follow the provider ecosystem and be ready to adapt when the path changed. Things really are moving too fast. I go on a vacation and miss a release, and suddenly my whole routing layer breaks because of a provider migration I didn't know was coming.
-3. Timeout policy is part of product behavior when LLMs are in the loop, connection is more akin to a session than a request, and the "request" can be arbitrarily long.
+3. Timeout policy is part of product behavior when LLMs are in the loop. A connection is more akin to a session than a request, and the "request" can be arbitrarily long.
+
+---
+
+## References
+
+- [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/)
+- [Gateway API Inference Extension](https://github.com/kubernetes-sigs/gateway-api-inference-extension)
+- [llm-d](https://github.com/llm-d/llm-d)
+- [agentgateway](https://agentgateway.dev/)
+- [kgateway release notes](https://kgateway.dev/docs/envoy/latest/reference/release-notes/)
+- [kgateway 2.2 breaking changes](https://kgateway.dev/docs/2.2.x/release-notes/breaking-changes/)
+- [Kubernetes: What is Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/#what-is-ingress)
+- [ingress-nginx retirement announcement](https://kubernetes.io/blog/2025/11/11/ingress-nginx-retirement/)
+- [Gateway API HTTP timeouts](https://gateway-api.sigs.k8s.io/guides/http-routing/#timeouts)


### PR DESCRIPTION
Introduce a new blog post detailing the challenges and lessons learned during the migration from Ingress to Gateway API for LLM routing. Update the content for clarity, refine section titles, and add a References section to enhance the post's usability. Adjustments improve the overall readability and structure of the article.