### PR TITLE
Add not_found_handling to assets configuration

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -6,7 +6,8 @@
     "enabled": true
   },
   "assets": {
-    "directory": "public"
+    "directory": "public",
+    "not_found_handling": "404-page"
   },
   "compatibility_flags": [
     "nodejs_compat"


### PR DESCRIPTION
Add a `not_found_handling` property to the assets configuration in `wrangler.jsonc` to specify a custom 404 page.